### PR TITLE
Add Client-Side ModMenu Badge

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,5 +25,8 @@
   },
   "suggests": {
     "flamingo": "*"
-  }
+  },
+   "custom": {
+   "modmenu:clientsideOnly": true
+   }
 }


### PR DESCRIPTION
Since it's a client-side only mod, it would be awesome to add [ModMenu](https://www.curseforge.com/minecraft/mc-mods/modmenu) support reflecting this.