### PR TITLE
corrected horse max speed and jump height

### DIFF
--- a/remappedSrc/monkey/lumpy/horse/stats/vanilla/util/Converter.java
+++ b/remappedSrc/monkey/lumpy/horse/stats/vanilla/util/Converter.java
@@ -2,10 +2,16 @@ package monkey.lumpy.horse.stats.vanilla.util;
 
 public class Converter {
     public static double jumpStrengthToJumpHeight(double strength) {
-        return -0.9078526641492174 * strength * strength * strength + 5.380296913832499 * strength * strength + 0.8696246225981936 * strength - 0.04348078381106464;
+        double height = 0;
+        double velocity = strength;
+        while(velocity > 0) {
+            height += velocity
+            velocity = (velocity - .08) * .98 * .98
+        }
+        return height;
     }
 
     public static double genericSpeedToBlocPerSec(double speed) {
-        return 42.15747598316077 * speed;
+        return 42.157796 * speed;
     }
 }

--- a/src/main/java/monkey/lumpy/horse/stats/vanilla/util/Converter.java
+++ b/src/main/java/monkey/lumpy/horse/stats/vanilla/util/Converter.java
@@ -2,10 +2,16 @@ package monkey.lumpy.horse.stats.vanilla.util;
 
 public class Converter {
     public static double jumpStrengthToJumpHeight(double strength) {
-        return -0.9078526641492174 * strength * strength * strength + 5.380296913832499 * strength * strength + 0.8696246225981936 * strength - 0.04348078381106464;
+        double height = 0;
+        double velocity = strength;
+        while(velocity > 0) {
+            height += velocity
+            velocity = (velocity - .08) * .98 * .98
+        }
+        return height;
     }
 
     public static double genericSpeedToBlocPerSec(double speed) {
-        return 42.15747598316077 * speed;
+        return 42.157796 * speed;
     }
 }

--- a/src/main/java/monkey/lumpy/horse/stats/vanilla/util/Converter.java
+++ b/src/main/java/monkey/lumpy/horse/stats/vanilla/util/Converter.java
@@ -5,8 +5,8 @@ public class Converter {
         double height = 0;
         double velocity = strength;
         while(velocity > 0) {
-            height += velocity
-            velocity = (velocity - .08) * .98 * .98
+            height += velocity;
+            velocity = (velocity - .08) * .98 * .98;
         }
         return height;
     }


### PR DESCRIPTION
accurate as of minecraft 1.19.4; I promise. horses on their original release in 1.6 lacked one of the multiplications by .98 in jump height (allowing for 5.9 block jumps!) and moved at the usual ~43.17 blocks/sec/internal speed units, both of which follow the more conventional physics of other objects in the game.